### PR TITLE
Fix: Modify the time_eval func in utils.py for killing timeout sub-process

### DIFF
--- a/hcga/feature_class.py
+++ b/hcga/feature_class.py
@@ -235,16 +235,13 @@ class FeatureClass:
 
         try:
             try:
-                feature = timeout_eval(
-                    feature_function, (function_args,), timeout=self.timeout, pool=self.pool
-                )
+                feature = timeout_eval(feature_function, (function_args,), timeout=self.timeout)
             except NetworkXNotImplemented:
                 if self.graph_type == "directed":
                     feature = timeout_eval(
                         feature_function,
                         (to_undirected(function_args),),
                         timeout=self.timeout,
-                        pool=self.pool,
                     )
                 else:
                     return None

--- a/hcga/utils.py
+++ b/hcga/utils.py
@@ -36,7 +36,7 @@ class NestedPool(multiprocessing.pool.Pool):  # pylint: disable=abstract-method
     Process = NoDaemonProcess
 
 
-def timeout_eval(func, args, timeout=None, pool=None):
+def timeout_eval(func, args, timeout=None):
     """Evaluate a function within a given timeout period.
 
     Args:
@@ -50,14 +50,14 @@ def timeout_eval(func, args, timeout=None, pool=None):
     if timeout is None or timeout == 0:
         try:
             return func(*args)
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             return None
 
     def target(queue, args):
         try:
             result = func(*args)
             queue.put(result)
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             queue.put(None)
 
     queue = multiprocessing.Queue()

--- a/hcga/utils.py
+++ b/hcga/utils.py
@@ -38,12 +38,12 @@ class NestedPool(multiprocessing.pool.Pool):  # pylint: disable=abstract-method
 
 def timeout_eval(func, args, timeout=None, pool=None):
     """Evaluate a function within a given timeout period.
-    
+
     Args:
         func: The function to call.
         args: Arguments to pass to the function.
         timeout: The timeout period in seconds.
-        
+
     Returns:
         The function's result, or None if a timeout or an error occurs.
     """

--- a/hcga/utils.py
+++ b/hcga/utils.py
@@ -37,14 +37,40 @@ class NestedPool(multiprocessing.pool.Pool):  # pylint: disable=abstract-method
 
 
 def timeout_eval(func, args, timeout=None, pool=None):
-    """Evaluate a function and kill it is it takes longer than timeout.
-
-    If timeout is Nonei or == 0, a simple evaluation will take place.
+    """Evaluate a function within a given timeout period.
+    
+    Args:
+        func: The function to call.
+        args: Arguments to pass to the function.
+        timeout: The timeout period in seconds.
+        
+    Returns:
+        The function's result, or None if a timeout or an error occurs.
     """
     if timeout is None or timeout == 0:
-        return func(*args)
+        try:
+            return func(*args)
+        except Exception:
+            return None
 
-    return pool.apply_async(func, args).get(timeout=timeout)
+    def target(queue, args):
+        try:
+            result = func(*args)
+            queue.put(result)
+        except Exception:
+            queue.put(None)
+
+    queue = multiprocessing.Queue()
+    process = multiprocessing.Process(target=target, args=(queue, args))
+    process.start()
+    process.join(timeout)
+
+    if process.is_alive():
+        process.terminate()
+        process.join()
+        return None
+
+    return queue.get_nowait()
 
 
 def get_trivial_graph(n_node_features=0):


### PR DESCRIPTION
Issue: pipe broken on Ubuntu 22.04
cause: too many zombie subprocesses are not killed when time out
fix: time_eval in utils.py
environment: python==3.8

P.S. It's my first time to make the open request. I'm not sure if I have an appropriate operation and discussion. If there is any trouble or mistake, please feel free to inform me.